### PR TITLE
Update GraphicsSettings.asset

### DIFF
--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -5,49 +5,47 @@ GraphicsSettings:
   m_ObjectHideFlags: 0
   serializedVersion: 16
   m_Deferred:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 69, guid: 0000000000000000f000000000000000, type: 0}
   m_DeferredReflections:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 74, guid: 0000000000000000f000000000000000, type: 0}
   m_ScreenSpaceShadows:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 64, guid: 0000000000000000f000000000000000, type: 0}
   m_DepthNormals:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 62, guid: 0000000000000000f000000000000000, type: 0}
   m_MotionVectors:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 75, guid: 0000000000000000f000000000000000, type: 0}
   m_LightHalo:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 105, guid: 0000000000000000f000000000000000, type: 0}
   m_LensFlare:
-    m_Mode: 1
+    m_Mode: 0
     m_Shader: {fileID: 102, guid: 0000000000000000f000000000000000, type: 0}
   m_VideoShadersIncludeMode: 2
-  m_AlwaysIncludedShaders:
-  - {fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 15105, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 10783, guid: 0000000000000000f000000000000000, type: 0}
+  m_AlwaysIncludedShaders:{fileID: 7, guid: 0000000000000000f000000000000000, type: 0}
+{fileID: 15104, guid: 0000000000000000f000000000000000, type: 0}
+{fileID: 15105, guid: 0000000000000000f000000000000000, type: 0}
+{fileID: 15106, guid: 0000000000000000f000000000000000, type: 0}
+{fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
+{fileID: 10783, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_PreloadShadersBatchTimeLimit: -1
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
-    type: 0}
+type: 0}
   m_CustomRenderPipeline: {fileID: 11400000, guid: 4b83569d67af61e458304325a23e5dfd,
-    type: 2}
+type: 2}
   m_TransparencySortMode: 0
   m_TransparencySortAxis: {x: 0, y: 0, z: 1}
   m_DefaultRenderingPath: 1
   m_DefaultMobileRenderingPath: 1
   m_TierSettings: []
-  m_LightmapStripping: 0
-  m_FogStripping: 0
-  m_InstancingStripping: 0
+  m_LightmapStripping: 1
+  m_FogStripping: 1
+  m_InstancingStripping: 2
   m_BrgStripping: 0
   m_LightmapKeepPlain: 1
   m_LightmapKeepDirCombined: 1
@@ -60,11 +58,12 @@ GraphicsSettings:
   m_FogKeepExp2: 1
   m_AlbedoSwatchInfos: []
   m_RenderPipelineGlobalSettingsMap:
-    UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: 18dc0cd2c080841dea60987a38ce93fa,
-      type: 2}
+UnityEngine.Rendering.Universal.UniversalRenderPipeline: {fileID: 11400000, guid: 18dc0cd2c080841dea60987a38ce93fa,
+  type: 2}
   m_LightsUseLinearIntensity: 1
   m_LightsUseColorTemperature: 1
   m_LogWhenShaderIsCompiled: 0
-  m_LightProbeOutsideHullStrategy: 0
-  m_CameraRelativeLightCulling: 0
-  m_CameraRelativeShadowCulling: 0
+  m_LightProbeOutsideHullStrategy: 1
+  m_CameraRelativeLightCulling: 1
+  m_CameraRelativeShadowCulling: 1
+


### PR DESCRIPTION
The upgrades and improvements include setting the m_Mode to 0 for all built-in pipeline features like m_Deferred, m_DeferredReflections, m_ScreenSpaceShadows, m_DepthNormals, m_MotionVectors, m_LightHalo, and m_LensFlare to disable support since the project uses URP, reducing unnecessary inclusions; removing the Standard shader (fileID: 10770) from m_AlwaysIncludedShaders as it is not needed in URP, which uses its own Lit shader, to optimize build size; enabling automatic stripping by setting m_LightmapStripping to 1 and m_FogStripping to 1 for reducing unused variants; setting m_InstancingStripping to 2 assuming it corresponds to 'Strip Unused' (the default and recommended for performance); changing m_LightProbeOutsideHullStrategy to 1 for extrapolation, improving lighting behavior outside probe hulls; and enabling m_CameraRelativeLightCulling and m_CameraRelativeShadowCulling to 1 for better performance in large worlds by avoiding floating-point precision issues. These changes aim to optimize for URP, improve performance, reduce build size, and incorporate best practices from recent Unity documentation without adding new fields beyond what's supported in the serializedVersion 16.